### PR TITLE
Fix overcounting stars because of inclusive range

### DIFF
--- a/src/Tags/Reviews.php
+++ b/src/Tags/Reviews.php
@@ -42,7 +42,7 @@ class Reviews extends Tags
 
             for ($star = 1; $star <= 5; $star++) {
                 $maxScore = $star * 2;
-                $minScore = $maxScore - 2;
+                $minScore = $maxScore - 1;
                 $reviewsCount = EntryFacade::query()
                     ->where('collection', 'reviews')
                     ->whereBetween('total_score', [$minScore, $maxScore])


### PR DESCRIPTION
I do notice that there is a marked difference (and probably something we can DRY) between this part and the same functionality that's in the ReviewsComposer class. This bit here groups it into stars whereas the other one leaves it as is and lets you use the 1-10 scale that FBC gives you.

We should probably nip this inconsistency in the bud before it becomes a backwards compatibility problem.